### PR TITLE
lytekit 0.15.35: pick up lyteidl 0.3.1, relax protobuf

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   host:
     - python {{ python_min }}
     - pip
+    - hatchling
     - setuptools
   run:
     - python >={{ python_min }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lytekit" %}
-{% set version = "0.15.30" %}
+{% set version = "0.15.35" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lytekit-{{ version }}.tar.gz
-  sha256: dbb6ea2b02ea6d5ae04a563da161b1713dc3ea083c30c8ec05c029524639f40a
+  sha256: 7498aa0c796ea62aa3acc699d722d797a2f9822c9937d946c5d81713a5089a2e
 
 build:
   noarch: python
@@ -29,7 +29,7 @@ requirements:
     - setuptools
   run:
     - python >={{ python_min }}
-    - lyteidl ==0.2.1
+    - lyteidl ==0.3.1
     - wheel >=0.30.0,<1.0.0
     - click >=6.6,<9.0
     - croniter >=0.3.20,<4.0.0
@@ -38,7 +38,7 @@ requirements:
     - python-dateutil >=2.1
     - grpcio >=1.43.0,!=1.45.0,<2.0
     - grpcio-status >=1.43,!=1.45.0
-    - protobuf >=3.6.1,<4
+    - protobuf >=3.20.3,<6
     - python-json-logger >=2.0.0
     - pytimeparse >=1.1.8,<2.0.0
     - pytz


### PR DESCRIPTION
## Summary

Bump `lytekit` 0.15.30 → 0.15.35 to pick up `lyteidl ==0.3.1`, which has regenerated protobuf bindings compatible with `protobuf >= 4` on Python 3.12.

- `lyteidl ==0.2.1` → `==0.3.1` (matches upstream `pyproject.toml`).
- `protobuf >=3.6.1,<4` → `>=3.20.3,<6` (matches upstream).

**Depends on conda-forge/lyteidl-feedstock#6** — that one needs to merge and rebuild first so this can resolve `lyteidl 0.3.1`.

Background: latchbio/latch#589.

Note on the existing autotick PRs (#5–#8): they cover 0.15.31–0.15.34. Jumping straight to 0.15.35 and bundling the `lyteidl` / `protobuf` updates avoids chaining four bumps; happy to defer to maintainer preference if you'd rather take them sequentially.

## Test plan

- conda-build succeeds on the configured matrix, including py3.12.
- Existing test commands (`import flytekit`, `pyflyte --help`, `flyte-cli --help`, `pip check`) continue to pass.